### PR TITLE
test: Configure coverage report

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,8 @@ The project uses [Jest](https://jestjs.io/) to run the tests, and it's already c
 
 The tests can be run with `yarn test` for interactive mode, or `yarn test:ci` for CI mode, where all the tests are run without user input.
 
+You can also run `yarn test:coverage`, which will run the tests and generate a coverage report on the console and in HTML format (`coverage` directory).
+
 ## 🚧 Committing
 
 This project uses the [Conventional Commits](https://www.conventionalcommits.org/) specification. This means that commit messages must adhere to the specification, so that they stay consistent and can be used to automatically generate change logs when releasing new versions.

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "test:ci": "CI=true yarn test",
+    "test:coverage": "CI=true react-scripts test --coverage",
     "eject": "react-scripts eject",
     "lint": "yarn lint:format && yarn lint:eslint && yarn lint:tsc",
     "lint:dry": "yarn lint:format:dry && yarn lint:eslint && yarn lint:tsc",
@@ -92,6 +93,26 @@
       "pre-commit": "lint-staged",
       "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
       "pre-push": "CI=true yarn test"
+    }
+  },
+  "jest": {
+    "coveragePathIgnorePatterns": [
+      "/node_modules/",
+      "src/stories",
+      "/src/reportWebVitals.ts",
+      "/src/index.tsx"
+    ],
+    "coverageReporters": [
+      "text",
+      "html"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "branches": 95,
+        "functions": 95,
+        "lines": 95,
+        "statements": -5
+      }
     }
   }
 }


### PR DESCRIPTION
Configure Jest's coverage report so that tests fail if coverage drops bellow the configured thresholds.

In order to not block a developer from pushing code in development to a remote server, the coverage requirements are not enforced in `yarn test`, and `yarn test:coverage` must be used to have the report.